### PR TITLE
persist column width

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -22,7 +22,12 @@ async function startup({ id, version, rootURI }) {
       "citationcounts-column-title"
     ),
     pluginID: id,
+    flex: 0,
+    width: 100,
+    minWidth: 45,
+    staticWidth: true,
     dataProvider: (item) => ZoteroCitationCounts.getCitationCount(item),
+    zoteroPersist: ['width', 'hidden', 'sortDirection'],  // persist the column properties
   });
 
   itemObserver = Zotero.Notifier.registerObserver(


### PR DESCRIPTION
These changes allow the column width can be persisted after restarting the Zotero.