### PR TITLE
use key: value format when inserting to field "Extra"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Boilerplate for this plugin was based on Zotero's sample plugin for v7 [Make-It-
 - Run Zotero (version 7.x)
 - Go to `Tools -> Add-ons`
 - `Install Add-on From File`
-- Choose the file `zoterocitationcountsmanager-2.0.0.xpi`
+- Choose the file `zoterocitationcountsmanager-2.0.1.xpi`
 - Restart Zotero
 
 ## License

--- a/bin/build
+++ b/bin/build
@@ -2,7 +2,7 @@
 
 cd ..
 
-version='2.0'
+version='2.0.1'
 
 rm -f zoterocitationcountsmanager-${version}.xpi
 zip -r zoterocitationcountsmanager-${version}.xpi locale/* manifest.json bootstrap.js preferences.js preferences.xhtml prefs.js zoterocitationcounts.js

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Zotero Citation Counts Manager",
-  "version": "2.0",
+  "version": "2.0.1",
   "description": "Enhanced Citation Counts Manager for Zotero 7",
   "homepage_url": "https://github.com/FrLars21/ZoteroCitationCountsManager",
   "applications": {

--- a/zoterocitationcounts.js
+++ b/zoterocitationcounts.js
@@ -389,13 +389,13 @@ ZoteroCitationCounts = {
    * Ref: https://www.zotero.org/support/kb/item_types_and_fields#citing_fields_from_extra
    */
   _setCitationCount: function (item, source, count) {
-    const pattern = /^Citations \(${source}\):|^\d+ citations \(${source}\)/i;
+    const pattern = /^Citations: \d+ \(${source}|^Citations \(${source}\):|^\d+ citations \(${source}\)/i;
     const extraFieldLines = (item.getField("extra") || "")
       .split("\n")
       .filter((line) => !pattern.test(line));
 
     const today = new Date().toISOString().split("T")[0];
-    extraFieldLines.unshift(`${count} citations (${source}) [${today}]`);
+    extraFieldLines.unshift(`Citations: ${count} (${source}, ${today})`);
 
     item.setField("extra", extraFieldLines.join("\n"));
     item.saveTx();


### PR DESCRIPTION
I like the plugin and thx @FrLars21 for porting it to Zotero7! This PR changes the way the retrieved citation counts are inserted into the "Extra" field of a record using a `key: value` structure: `Citations: <count> (<source>, <date>)`. For me this is preferable as it makes it easier to be read automatically from the resulting bib-file when you export the record.